### PR TITLE
refactor: remove query parameters from request url 

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -15,8 +15,7 @@ export class Request {
 
   get(
     requestUrl: string,
-    searchParams?: Record<string, string | number | boolean | undefined>,
-    prefixUrl?: string
+    searchParams?: Record<string, string | number | boolean | undefined>
   ) {
     this.options = {
       url: requestUrl,
@@ -24,7 +23,6 @@ export class Request {
       headers: this.headers,
       responseType: "json",
       searchParams,
-      prefixUrl,
     };
 
     return this;

--- a/src/client.ts
+++ b/src/client.ts
@@ -13,12 +13,18 @@ export class Request {
     this.headers[key] = value;
   }
 
-  get(requestUrl: string) {
+  get(
+    requestUrl: string,
+    searchParams?: Record<string, string | number | boolean | undefined>,
+    prefixUrl?: string
+  ) {
     this.options = {
       url: requestUrl,
       method: "GET",
       headers: this.headers,
       responseType: "json",
+      searchParams,
+      prefixUrl,
     };
 
     return this;

--- a/src/client.ts
+++ b/src/client.ts
@@ -15,11 +15,10 @@ export class Request {
 
   get(
     requestUrl: string,
-    path: string = "",
     searchParams?: Record<string, string | number | boolean | undefined>
   ) {
     this.options = {
-      url: requestUrl + `/${path}`,
+      url: requestUrl,
       method: "GET",
       headers: this.headers,
       responseType: "json",

--- a/src/client.ts
+++ b/src/client.ts
@@ -15,10 +15,11 @@ export class Request {
 
   get(
     requestUrl: string,
+    path: string = "",
     searchParams?: Record<string, string | number | boolean | undefined>
   ) {
     this.options = {
-      url: requestUrl,
+      url: requestUrl + `/${path}`,
       method: "GET",
       headers: this.headers,
       responseType: "json",

--- a/src/keploy.ts
+++ b/src/keploy.ts
@@ -68,25 +68,25 @@ export default class Keploy {
   }
 
   async get(id: ID) {
-    const requestUrl = "regression/testcase";
+    const requestUrl = `regression/testcase/${id}`;
     const request = new Request();
     request.setHttpHeader("key", this.serverConfig.licenseKey);
 
-    return this.client.makeHttpRequest(request.get(requestUrl, id));
+    return this.client.makeHttpRequest(request.get(requestUrl));
   }
 
   private start(total: number) {
     const app = this.appConfig.name;
     const requestUrl = "regression/start";
     return this.client.makeHttpRequest(
-      new Request().get(requestUrl, undefined, { app, total })
+      new Request().get(requestUrl, { app, total })
     );
   }
 
   private end(id: ID, status: boolean) {
     const requestUrl = "regression/end";
     return this.client.makeHttpRequest(
-      new Request().get(requestUrl, undefined, { status, id })
+      new Request().get(requestUrl, { status, id })
     );
   }
 
@@ -126,7 +126,7 @@ export default class Keploy {
       const request = new Request();
       this.setKey(request);
       const response = await this.client.makeHttpRequest(
-        request.get(requestUrl, undefined, { app, offset, limit })
+        request.get(requestUrl, { app, offset, limit })
       );
 
       testCases.push(response);

--- a/src/keploy.ts
+++ b/src/keploy.ts
@@ -72,21 +72,21 @@ export default class Keploy {
     const request = new Request();
     request.setHttpHeader("key", this.serverConfig.licenseKey);
 
-    return this.client.makeHttpRequest(request.get(requestUrl, { id }));
+    return this.client.makeHttpRequest(request.get(requestUrl, id));
   }
 
   private start(total: number) {
     const app = this.appConfig.name;
     const requestUrl = "regression/start";
     return this.client.makeHttpRequest(
-      new Request().get(requestUrl, { app, total })
+      new Request().get(requestUrl, undefined, { app, total })
     );
   }
 
   private end(id: ID, status: boolean) {
     const requestUrl = "regression/end";
     return this.client.makeHttpRequest(
-      new Request().get(requestUrl, { status, id })
+      new Request().get(requestUrl, undefined, { status, id })
     );
   }
 
@@ -126,7 +126,7 @@ export default class Keploy {
       const request = new Request();
       this.setKey(request);
       const response = await this.client.makeHttpRequest(
-        request.get(requestUrl, { app, offset, limit })
+        request.get(requestUrl, undefined, { app, offset, limit })
       );
 
       testCases.push(response);

--- a/src/keploy.ts
+++ b/src/keploy.ts
@@ -68,22 +68,26 @@ export default class Keploy {
   }
 
   async get(id: ID) {
-    const requestUrl = `regression/testcase/${id}`;
+    const requestUrl = "regression/testcase";
     const request = new Request();
     request.setHttpHeader("key", this.serverConfig.licenseKey);
 
-    return this.client.makeHttpRequest(request.get(requestUrl));
+    return this.client.makeHttpRequest(request.get(requestUrl, undefined, id));
   }
 
   private start(total: number) {
     const app = this.appConfig.name;
-    const requestUrl = `regression/start?app=${app}&total=${total}`;
-    return this.client.makeHttpRequest(new Request().get(requestUrl));
+    const requestUrl = "regression/start";
+    return this.client.makeHttpRequest(
+      new Request().get(requestUrl, { app, total })
+    );
   }
 
   private end(id: ID, status: boolean) {
-    const requestUrl = `regression/end?status=${status}&id=${id}`;
-    return this.client.makeHttpRequest(new Request().get(requestUrl));
+    const requestUrl = "regression/end";
+    return this.client.makeHttpRequest(
+      new Request().get(requestUrl, { status, id })
+    );
   }
 
   private simulate(tc: TestCase) {
@@ -118,11 +122,11 @@ export default class Keploy {
     const testCases = [];
 
     while (true) {
-      const requestUrl = `regression/testcase?app=${app}&offset=${offset}&limit=${limit}`;
+      const requestUrl = "regression/testcase";
       const request = new Request();
       this.setKey(request);
       const response = await this.client.makeHttpRequest(
-        request.get(requestUrl)
+        request.get(requestUrl, { app, offset, limit })
       );
 
       testCases.push(response);

--- a/src/keploy.ts
+++ b/src/keploy.ts
@@ -72,7 +72,7 @@ export default class Keploy {
     const request = new Request();
     request.setHttpHeader("key", this.serverConfig.licenseKey);
 
-    return this.client.makeHttpRequest(request.get(requestUrl, undefined, id));
+    return this.client.makeHttpRequest(request.get(requestUrl, { id }));
   }
 
   private start(total: number) {


### PR DESCRIPTION
removed query parameters from request url and added searchParams and prefixUrl in get method of request class in client.ts