### PR TITLE
fix(express): converts headers into required key:value type

### DIFF
--- a/src/keploy.ts
+++ b/src/keploy.ts
@@ -40,7 +40,7 @@ type TestCaseRequest = {
   appId: string;
   uri: string;
   httpReq: object;
-  httpRes: object;
+  httpResp: object;
 };
 
 export default class Keploy {


### PR DESCRIPTION
keploy server requires headers value type to be an array of string. Due to this response and request
header's value type was converted.