### PR TITLE
feat: read config from environment variables

### DIFF
--- a/integrations/express/register.ts
+++ b/integrations/express/register.ts
@@ -1,6 +1,7 @@
 // @ts-ignore
 import Hook from "require-in-the-middle";
 import expressMiddleware from "./middleware";
+import Keploy from "../../src/keploy";
 
 // @ts-ignore
 Hook(["express"], function (exports) {
@@ -9,7 +10,9 @@ Hook(["express"], function (exports) {
   function keployWrappedExpress() {
     const keployApp = expressApp();
 
-    keployApp.use(expressMiddleware);
+    const keploy = new Keploy();
+
+    keployApp.use(expressMiddleware(keploy));
     keployApp.appliedMiddleware = true;
 
     return keployApp;

--- a/src/keploy.ts
+++ b/src/keploy.ts
@@ -50,12 +50,59 @@ export default class Keploy {
   dependencies: Record<ID, unknown>;
   client: HttpClient;
 
-  constructor(app: AppConfig, server: ServerConfig) {
-    this.appConfig = app;
-    this.serverConfig = server;
+  constructor(
+    app: Partial<AppConfig> = {},
+    server: Partial<ServerConfig> = {}
+  ) {
+    this.appConfig = this.validateAppConfig(app);
+    this.serverConfig = this.validateServerConfig(server);
     this.responses = {};
     this.dependencies = {};
     this.client = new HttpClient(this.serverConfig.url);
+  }
+
+  validateServerConfig({
+    url = process.env.KEPLOY_SERVER_URL || "http://localhost:8081/api",
+    licenseKey = process.env.KEPLOY_LICENSE_KEY || "",
+  }) {
+    return { url, licenseKey };
+  }
+
+  validateAppConfig({
+    name = process.env.KEPLOY_APP_NAME || "keploy-app",
+    host = process.env.KEPLOY_APP_HOST || "localhost",
+    port = process.env.KEPLOY_APP_PORT || 8080,
+    delay = process.env.KEPLOY_APP_DELAY || 5,
+    timeout = process.env.KEPLOY_APP_TIMEOUT || 60,
+    filter = process.env.KEPLOY_APP_FILTER || {},
+  }) {
+    const errorFactory = (key: string) =>
+      new Error(`Invalid App config key: ${key}`);
+
+    port = Number(port);
+    if (Number.isNaN(port)) {
+      throw errorFactory("port");
+    }
+
+    delay = Number(delay);
+    if (Number.isNaN(delay)) {
+      throw errorFactory("delay");
+    }
+
+    timeout = Number(timeout);
+    if (Number.isNaN(timeout)) {
+      throw errorFactory("timeout");
+    }
+
+    if (typeof filter === "string") {
+      try {
+        filter = JSON.parse(filter);
+      } catch {
+        throw errorFactory("filter");
+      }
+    }
+
+    return { name, host, port, delay, timeout, filter };
   }
 
   getDependencies(id: ID) {


### PR DESCRIPTION
This will allow Keploy to be initialised without arguments which is helpful for `register` method. If these environment variables are found the config values will be initialised based on these, otherwise a default value will be set.

```sh
KEPLOY_APP_NAME=hello
KEPLOY_APP_HOST=localhost
KEPLOY_APP_PORT=8000
KEPLOY_APP_DELAY=5 # should be number
KEPLOY_APP_TIMEOUT=100 # should be number
KEPLOY_APP_FILTER={"urlRegex":"*"}  # should be json

KEPLOY_SERVER_URL=http://localhost:8001/api
KEPLOY_SERVER_LICENSE=3F813077-1465-4B5C-A477-AB2856FB29E8
```
