### PR TITLE
fix: updates the default url for self-hosted Keploy

### DIFF
--- a/src/keploy.ts
+++ b/src/keploy.ts
@@ -80,7 +80,7 @@ export default class Keploy {
   }
 
   validateServerConfig({
-    url = process.env.KEPLOY_SERVER_URL || "http://localhost:8081/api",
+    url = process.env.KEPLOY_SERVER_URL || "http://localhost:6789/api",
     licenseKey = process.env.KEPLOY_LICENSE_KEY || "",
   }) {
     return { url, licenseKey };


### PR DESCRIPTION
the default port of Keploy server is updated to 6789, therefore the default url in server-config needs to be updated in Keploy class.
