### PR TITLE
fix: stores correct http response for unique test-ids

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1,8 +1,8 @@
-import http, { Headers, OptionsOfJSONResponseBody, Response } from "got";
+import http, { Headers, Options } from "got";
 
 export class Request {
   headers: Headers;
-  options: OptionsOfJSONResponseBody;
+  options: Options;
 
   constructor() {
     this.headers = { "User-Agent": "keploy-typescript-sdk" };
@@ -32,7 +32,7 @@ export class Request {
       url: requestUrl,
       method: "GET",
       headers: this.headers,
-      responseType: "json",
+      responseType: "buffer",
       searchParams,
     };
 
@@ -49,7 +49,7 @@ export class Request {
       url: requestUrl,
       method: "POST",
       headers: this.headers,
-      responseType: "json",
+      responseType: "buffer",
       searchParams,
     };
 
@@ -82,7 +82,7 @@ export class Request {
       url: requestUrl,
       method: "PUT",
       headers: this.headers,
-      responseType: "json",
+      responseType: "buffer",
       searchParams,
     };
 
@@ -99,7 +99,7 @@ export class Request {
       url: requestUrl,
       method: "PATCH",
       headers: this.headers,
-      responseType: "json",
+      responseType: "buffer",
       searchParams,
     };
 
@@ -136,14 +136,12 @@ export default class HttpClient {
     this.baseUrl = baseUrl;
   }
 
-  async makeHttpRequest<T>(request: Request): Promise<T> {
+  async makeHttpRequestRaw(request: Request) {
     const options = { ...request.raw(), prefixUrl: this.baseUrl };
-    return http(options).json();
-  }
-
-  async makeHttpRequestRaw<T>(request: Request): Promise<Response<T>> {
-    const options = { ...request.raw(), prefixUrl: this.baseUrl };
-    const resp: Response<T> = await http(options);
-    return resp;
+    try {
+      await http(options);
+    } catch (error) {
+      console.log(error);
+    }
   }
 }

--- a/src/keploy.ts
+++ b/src/keploy.ts
@@ -153,8 +153,13 @@ export default class Keploy {
     return this.responses[id];
   }
 
+  // stores http response for unique test-ids to capture them at middleware layer
   putResp(id: ID, resp: HttpResponse) {
-    this.responses[id] = resp;
+    // put http response in map only once for unique test-ids. Since, finish event
+    // can trigger multiple time for redirect.
+    if (this.responses[id] === null || this.responses[id] === undefined) {
+      this.responses[id] = resp;
+    }
   }
 
   capture(req: TestCaseReq) {
@@ -348,7 +353,7 @@ export default class Keploy {
     //@ts-ignore
     const requestUrl = `${tc.HttpReq?.URL.substr(1)}`;
 
-    await client.makeHttpRequestRaw<object>(
+    await client.makeHttpRequestRaw(
       new Request()
         .setHttpHeader("KEPLOY_TEST_ID", tc.id)
         //@ts-ignore


### PR DESCRIPTION
Since, finish event is called twice for redirect responses due to which the status code is not 3XX. 
This is solved by storing http responses only once in Keploy's responses map.