### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,4 +32,4 @@ jobs:
           cmd: build
 
       - name: Check commits messages
-        uses: wagoid/commitlint-github-action@v3
+        uses: wagoid/commitlint-github-action@v5


### PR DESCRIPTION
Need to update the commitzen linter version due to deprecated "set-output" git cmd.