### PR TITLE
fix(node-fetch): empty response

### DIFF
--- a/integrations/node-fetch/require.ts
+++ b/integrations/node-fetch/require.ts
@@ -42,7 +42,7 @@ export function wrappedNodeFetch(fetch: any) {
       getExecutionContext().context == undefined
     ) {
       console.error("keploy context is not present to mock dependencies");
-      return;
+      return fetchFunc.apply(this, [url, options]);
     }
     const ctx = getExecutionContext().context;
     let resp = new fetch.Response();


### PR DESCRIPTION
- fixes https://github.com/keploy/keploy/issues/376
- I'm not entirely sure about the cases where we create a new `context`.
  - Since this is a dependency I think we shouldn't create one? (in all cases off/record/test) and only create context when we have the main app (i.e. express) integrated in code.
- I treated it like the `switch-case` code below when it's `off`.