### PR TITLE
Fix sdk records test case in record mode

### DIFF
--- a/integrations/express/middleware.ts
+++ b/integrations/express/middleware.ts
@@ -4,6 +4,7 @@ import Keploy, { HTTP } from "../../src/keploy";
 import { Request, Response, NextFunction } from "express";
 import { createExecutionContext, getExecutionContext } from "../../src/context";
 import { StrArr } from "../../proto/services/StrArr";
+import { MODE_TEST, MODE_RECORD, MODE_OFF } from "../../src/mode";
 
 class ResponseBody {
   static responseMap = new WeakMap<Request, ResponseBody>();
@@ -72,10 +73,10 @@ export default function middleware(
     });
     if (
       (process.env.KEPLOY_MODE != undefined &&
-        process.env.KEPLOY_MODE == "off") ||
+        process.env.KEPLOY_MODE == MODE_OFF) ||
       keploy == undefined
     ) {
-      createExecutionContext({ mode: "off" });
+      createExecutionContext({ mode: MODE_OFF });
       next();
       return;
     }
@@ -84,7 +85,7 @@ export default function middleware(
     // test mode
     if (id != undefined && id != "") {
       createExecutionContext({
-        mode: "test",
+        mode: MODE_TEST,
         testId: id,
         deps: keploy.getDependencies(id),
         mocks: keploy.getMocks(id),
@@ -94,7 +95,7 @@ export default function middleware(
     }
 
     // record mode
-    createExecutionContext({ mode: "record", deps: [], mocks: [] });
+    createExecutionContext({ mode: MODE_RECORD, deps: [], mocks: [] });
     captureResp(req, res, next);
   };
 }
@@ -118,7 +119,7 @@ function captureResp(
 export function afterMiddleware(keploy: Keploy, req: Request, res: Response) {
   if (
     (process.env.KEPLOY_MODE != undefined &&
-      process.env.KEPLOY_MODE == "off") ||
+      process.env.KEPLOY_MODE == MODE_OFF) ||
     keploy == undefined
   ) {
     return;
@@ -140,7 +141,7 @@ export function afterMiddleware(keploy: Keploy, req: Request, res: Response) {
   }
 
   //to avoid recording tests in the test mode and only recording in the record mode
-  if (process.env.KEPLOY_MODE == "test" && id === undefined) {
+  if (process.env.KEPLOY_MODE == MODE_TEST && id === undefined) {
     return;
   }
 

--- a/integrations/express/middleware.ts
+++ b/integrations/express/middleware.ts
@@ -139,6 +139,11 @@ export function afterMiddleware(keploy: Keploy, req: Request, res: Response) {
     return;
   }
 
+  //to avoid recording tests in the test mode and only recording in the record mode
+  if (process.env.KEPLOY_MODE == "test" && id === undefined) {
+    return;
+  }
+
   // req.headers
   // Since, JSON.stingify trims spaces. Therefore, content-length of request header should be updated
   req.headers["content-length"] = JSON.stringify(
@@ -160,30 +165,28 @@ export function afterMiddleware(keploy: Keploy, req: Request, res: Response) {
     mocks = kctx.context.mocks;
   }
 
-  if (kctx.context.mode == "test") {
-    keploy.capture({
-      Captured: Date.now(),
-      AppID: keploy.appConfig.name,
-      // change url to uri ex: /url-shortner/:param
-      URI: req.originalUrl,
-      HttpReq: {
-        Method: req.method,
-        URL: req.originalUrl,
-        URLParams: req.params,
-        Header: reqHeader,
-        Body: JSON.stringify(req.body),
-      },
-      HttpResp: {
-        StatusCode: res.statusCode,
-        Header: respHeader,
-        // @ts-ignore
-        Body: String(ResponseBody.get(req)),
-      },
-      Dependency: deps,
-      TestCasePath: keploy.appConfig.testCasePath,
-      MockPath: keploy.appConfig.mockPath,
-      Mocks: mocks,
-      Type: HTTP,
-    });
-  }
+  keploy.capture({
+    Captured: Date.now(),
+    AppID: keploy.appConfig.name,
+    // change url to uri ex: /url-shortner/:param
+    URI: req.originalUrl,
+    HttpReq: {
+      Method: req.method,
+      URL: req.originalUrl,
+      URLParams: req.params,
+      Header: reqHeader,
+      Body: JSON.stringify(req.body),
+    },
+    HttpResp: {
+      StatusCode: res.statusCode,
+      Header: respHeader,
+      // @ts-ignore
+      Body: String(ResponseBody.get(req)),
+    },
+    Dependency: deps,
+    TestCasePath: keploy.appConfig.testCasePath,
+    MockPath: keploy.appConfig.mockPath,
+    Mocks: mocks,
+    Type: HTTP,
+  });
 }

--- a/integrations/express/middleware.ts
+++ b/integrations/express/middleware.ts
@@ -10,8 +10,6 @@ import {
 import { StrArr } from "../../proto/services/StrArr";
 import { MODE_TEST, MODE_RECORD, MODE_OFF } from "../../src/mode";
 
-import { MODE_OFF, MODE_RECORD, MODE_TEST } from "../../src/mode";
-
 class ResponseBody {
   static responseMap = new WeakMap<Request, ResponseBody>();
 
@@ -79,7 +77,7 @@ export default function middleware(
     });
     if (
       (process.env.KEPLOY_MODE != undefined &&
-        process.env.KEPLOY_MODE == MODE_OFF) ||
+        keploy.mode.GetMode() == MODE_OFF) ||
       keploy == undefined
     ) {
       createExecutionContext({ mode: MODE_OFF });
@@ -139,7 +137,7 @@ function captureResp(
 export function afterMiddleware(keploy: Keploy, req: Request, res: Response) {
   if (
     (process.env.KEPLOY_MODE != undefined &&
-      process.env.KEPLOY_MODE == MODE_OFF) ||
+      keploy.mode.GetMode() == MODE_OFF) ||
     keploy == undefined
   ) {
     return;
@@ -162,7 +160,7 @@ export function afterMiddleware(keploy: Keploy, req: Request, res: Response) {
   }
 
   //to avoid recording tests in the test mode and only recording in the record mode
-  if (process.env.KEPLOY_MODE == MODE_TEST && id === undefined) {
+  if (keploy.mode.GetMode() == MODE_OFF && id === undefined) {
     return;
   }
 

--- a/integrations/express/middleware.ts
+++ b/integrations/express/middleware.ts
@@ -160,28 +160,30 @@ export function afterMiddleware(keploy: Keploy, req: Request, res: Response) {
     mocks = kctx.context.mocks;
   }
 
-  keploy.capture({
-    Captured: Date.now(),
-    AppID: keploy.appConfig.name,
-    // change url to uri ex: /url-shortner/:param
-    URI: req.originalUrl,
-    HttpReq: {
-      Method: req.method,
-      URL: req.originalUrl,
-      URLParams: req.params,
-      Header: reqHeader,
-      Body: JSON.stringify(req.body),
-    },
-    HttpResp: {
-      StatusCode: res.statusCode,
-      Header: respHeader,
-      // @ts-ignore
-      Body: String(ResponseBody.get(req)),
-    },
-    Dependency: deps,
-    TestCasePath: keploy.appConfig.testCasePath,
-    MockPath: keploy.appConfig.mockPath,
-    Mocks: mocks,
-    Type: HTTP,
-  });
+  if (kctx.context.mode == "test") {
+    keploy.capture({
+      Captured: Date.now(),
+      AppID: keploy.appConfig.name,
+      // change url to uri ex: /url-shortner/:param
+      URI: req.originalUrl,
+      HttpReq: {
+        Method: req.method,
+        URL: req.originalUrl,
+        URLParams: req.params,
+        Header: reqHeader,
+        Body: JSON.stringify(req.body),
+      },
+      HttpResp: {
+        StatusCode: res.statusCode,
+        Header: respHeader,
+        // @ts-ignore
+        Body: String(ResponseBody.get(req)),
+      },
+      Dependency: deps,
+      TestCasePath: keploy.appConfig.testCasePath,
+      MockPath: keploy.appConfig.mockPath,
+      Mocks: mocks,
+      Type: HTTP,
+    });
+  }
 }


### PR DESCRIPTION
Fixes: [#430 ](https://github.com/keploy/keploy/issues/430)
TS-SDK was saving tests in `test` mode also which shouldn't be the case, it should only save tests in the `record` mode. 
I have figured out the correct location to apply the correct if condition.