### PR TITLE
fix(src/utils): adds ctx parameter in processDep

### DIFF
--- a/integrations/mongoose/delete.ts
+++ b/integrations/mongoose/delete.ts
@@ -35,7 +35,7 @@ export function kDeleteOne(...args) {
           // wrap callback of updateOne to capture the mongodb-native-driver outputs
           // @ts-ignore
           args[args.length - 1] = function (...outputs) {
-            ProcessDep(meta, ...outputs);
+            ProcessDep(ctx, meta, ...outputs);
             // calls the actual mongoose callback for findOne
             callback.apply(this, outputs);
           };
@@ -50,7 +50,7 @@ export function kDeleteOne(...args) {
         if (typeof callback === "function") {
           // mocked outputs of updateOne opperation
           const outputs: any[] = [null, {}];
-          const mocks = ProcessDep(meta, ...outputs);
+          const mocks = ProcessDep(ctx, meta, ...outputs);
           // calls the actual mongoose callback for findOne
           // @ts-ignore
           callback.apply(this, mocks);
@@ -102,7 +102,7 @@ export function kDeleteMany(...args) {
           // wrap callback of deleteMany to capture the mongodb-native-driver outputs
           // @ts-ignore
           args[args.length - 1] = function (...outputs) {
-            ProcessDep(meta, ...outputs);
+            ProcessDep(ctx, meta, ...outputs);
             // calls the actual mongoose callback for findOne
             callback.apply(this, outputs);
           };
@@ -117,7 +117,7 @@ export function kDeleteMany(...args) {
         if (typeof callback === "function") {
           // mocked outputs of deleteMany opperation
           const outputs: any[] = [null, {}];
-          const mocks = ProcessDep(meta, ...outputs);
+          const mocks = ProcessDep(ctx, meta, ...outputs);
           // calls the actual mongoose callback for findOne
           // @ts-ignore
           callback.apply(this, mocks);

--- a/integrations/mongoose/find.ts
+++ b/integrations/mongoose/find.ts
@@ -35,7 +35,7 @@ export function kFindOne(...args) {
           // wrap callback of findOne to capture the mongodb-native-driver outputs
           // @ts-ignore
           args[args.length - 1] = function (...outputs) {
-            ProcessDep(meta, ...outputs);
+            ProcessDep(ctx, meta, ...outputs);
             // calls the actual mongoose callback for findOne
             callback.apply(this, outputs);
           };
@@ -51,7 +51,7 @@ export function kFindOne(...args) {
         if (typeof callback === "function") {
           // mocked outputs of findOne opperation
           const outputs: any[] = [null, {}];
-          const mocks = ProcessDep(meta, ...outputs);
+          const mocks = ProcessDep(ctx, meta, ...outputs);
           // calls the actual mongoose callback for findOne
           // @ts-ignore
           callback.apply(this, mocks);
@@ -110,7 +110,7 @@ export function kFind(...args) {
                 // call the actual toArray method of cursor
                 const result = await actualToArray.apply(outputs[1], cb);
                 // encode and stores the documents in executionContext
-                ProcessDep(meta, outputs[0], result);
+                ProcessDep(ctx, meta, outputs[0], result);
                 // calls the actual user defined callback
                 cb(outputs[0], result);
                 return result;
@@ -135,7 +135,7 @@ export function kFind(...args) {
           const outputs = [null, {}];
           let result: any[] = [];
           // returns the mocked outputs of find call
-          const mocks = ProcessDep(meta, outputs[0], result);
+          const mocks = ProcessDep(ctx, meta, outputs[0], result);
           if (mocks !== undefined && mocks.length == 2) {
             result = mocks[1];
             outputs[0] = mocks[0];

--- a/integrations/mongoose/insert.ts
+++ b/integrations/mongoose/insert.ts
@@ -34,7 +34,7 @@ export function kInsertMany(...args) {
           // wrap callback of insertMany to capture the mongodb-native-driver outputs
           // @ts-ignore
           args[args.length - 1] = function (...outputs) {
-            ProcessDep(meta, ...outputs);
+            ProcessDep(ctx, meta, ...outputs);
             // calls the actual mongoose callback for findOne
             callback.apply(this, outputs);
           };
@@ -49,7 +49,7 @@ export function kInsertMany(...args) {
         if (typeof callback === "function") {
           // mocked outputs of insertMany opperation
           const outputs: any[] = [null, {}];
-          const mocks = ProcessDep(meta, ...outputs);
+          const mocks = ProcessDep(ctx, meta, ...outputs);
           // calls the actual mongoose callback for findOne
           // @ts-ignore
           callback.apply(this, mocks);
@@ -100,7 +100,7 @@ export function kInsertOne(...args) {
           // wrap callback of insertOne to capture the mongodb-native-driver outputs
           // @ts-ignore
           args[args.length - 1] = function (...outputs) {
-            ProcessDep(meta, ...outputs);
+            ProcessDep(ctx, meta, ...outputs);
             // calls the actual mongoose callback for findOne
             callback.apply(this, outputs);
           };
@@ -115,7 +115,7 @@ export function kInsertOne(...args) {
         if (typeof callback === "function") {
           // mocked outputs of insertOne opperation
           const outputs: any[] = [null, {}];
-          const mocks = ProcessDep(meta, ...outputs);
+          const mocks = ProcessDep(ctx, meta, ...outputs);
           // calls the actual mongoose callback for findOne
           // @ts-ignore
           callback.apply(this, mocks);

--- a/integrations/mongoose/update.ts
+++ b/integrations/mongoose/update.ts
@@ -34,7 +34,7 @@ export function kUpdateOne(...args) {
           // wrap callback of updateOne to capture the mongodb-native-driver outputs
           // @ts-ignore
           args[args.length - 1] = function (...outputs) {
-            ProcessDep(meta, ...outputs);
+            ProcessDep(ctx, meta, ...outputs);
             // calls the actual mongoose callback for findOne
             callback.apply(this, outputs);
           };
@@ -49,7 +49,7 @@ export function kUpdateOne(...args) {
         if (typeof callback === "function") {
           // mocked outputs of updateOne opperation
           const outputs: any[] = [null, {}];
-          const mocks = ProcessDep(meta, ...outputs);
+          const mocks = ProcessDep(ctx, meta, ...outputs);
           // calls the actual mongoose callback for findOne
           // @ts-ignore
           callback.apply(this, mocks);
@@ -102,7 +102,7 @@ export function kUpdateMany(...args) {
           // wrap callback of updateMany to capture the mongodb-native-driver outputs
           // @ts-ignore
           args[args.length - 1] = function (...outputs) {
-            ProcessDep(meta, ...outputs);
+            ProcessDep(ctx, meta, ...outputs);
             // calls the actual mongoose callback for findOne
             callback.apply(this, outputs);
           };
@@ -117,7 +117,7 @@ export function kUpdateMany(...args) {
         if (typeof callback === "function") {
           // mocked outputs of updateMany opperation
           const outputs: any[] = [null, {}];
-          const mocks = ProcessDep(meta, ...outputs);
+          const mocks = ProcessDep(ctx, meta, ...outputs);
           // calls the actual mongoose callback for findOne
           // @ts-ignore
           callback.apply(this, mocks);

--- a/integrations/node-fetch/require.ts
+++ b/integrations/node-fetch/require.ts
@@ -133,7 +133,7 @@ export function wrappedNodeFetch(fetch: any) {
           }
           ctx.mocks.shift();
         } else {
-          ProcessDep({}, outputs);
+          ProcessDep(ctx, {}, outputs);
         }
         rinit.headers = new Headers(outputs[1].headers);
         rinit.status = outputs[1].status;

--- a/integrations/octokit/require.ts
+++ b/integrations/octokit/require.ts
@@ -189,7 +189,7 @@ export function wrappedNodeFetch(fetchFunc: Function) {
           }
           ctx.mocks.shift();
         } else {
-          ProcessDep({}, outputs);
+          ProcessDep(ctx, {}, outputs);
         }
         rinit.headers = new Headers(outputs[1].headers);
         rinit.status = outputs[1].status;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "commit": "cz"
   },
   "repository": "git@github.com:keploy/typescript-sdk.git",
-  "author": "Rajat Sharma <lunasunkaiser@gmail.com>",
+  "author": "Keploy <dev@keploy.io>",
   "license": "MIT",
   "devDependencies": {
     "@commitlint/cli": "^16.2.1",

--- a/src/util.ts
+++ b/src/util.ts
@@ -25,15 +25,19 @@ const transformToSnakeCase = (obj: any): object => {
 
 export { transformToSnakeCase };
 
-export function ProcessDep(meta: { [key: string]: string }, ...outputs: any[]) {
-  if (
-    getExecutionContext() == undefined ||
-    getExecutionContext().context == undefined
-  ) {
-    console.error("keploy context is not present to mock dependencies");
-    return;
-  }
-  const kctx = getExecutionContext().context;
+export function ProcessDep(
+  kctx: any,
+  meta: { [key: string]: string },
+  ...outputs: any[]
+) {
+  // if (
+  //   getExecutionContext() == undefined ||
+  //   getExecutionContext().context == undefined
+  // ) {
+  //   console.error("keploy context is not present to mock dependencies");
+  //   return;
+  // }
+  // const kctx = getExecutionContext().context;
   switch (kctx.mode) {
     case "record":
       const res: DataBytes[] = [];


### PR DESCRIPTION
the executionContext was getting undefined for mocking dependency call outputs