### PR TITLE
Fix empty response for http node-fetch call

### DIFF
--- a/integrations/node-fetch/require.ts
+++ b/integrations/node-fetch/require.ts
@@ -43,7 +43,7 @@ export function wrappedNodeFetch(fetch: any) {
       getExecutionContext().context == undefined
     ) {
       console.error("keploy context is not present to mock dependencies");
-      return;
+      return fetchFunc.apply(this, [url, options]);
     }
     const ctx = getExecutionContext().context;
     let resp = new fetch.Response();


### PR DESCRIPTION
Fixes [#376](https://github.com/keploy/keploy/issues/376)
The bug is fixed by treating the `no keploy context` case just like the case when the `KEPLOY_MODE` is `off`. We don't need to change the context of the function calls.