### PR TITLE
Logs the mode and description of keploy

### DIFF
--- a/mock/mock.ts
+++ b/mock/mock.ts
@@ -62,6 +62,8 @@ export function NewContext(conf: Config) {
     mode.SetMode(conf.Mode);
   }
   console.log("Keploy is running in " + mode.GetMode() + " mode");
+  modeDescription(mode.GetMode());
+
   switch (mode.GetMode()) {
     case MODE_TEST:
       if (conf.Name === "") {
@@ -115,4 +117,24 @@ export function NewContext(conf: Config) {
     name,
     conf.Name
   );
+}
+
+function modeDescription(mode: string) {
+  switch (mode) {
+    case MODE_RECORD:
+      console.log(
+        "This mode will record all the API calls made to the application and store each call as a test in the keploy/tests directory as a yaml file"
+      );
+      break;
+    case MODE_TEST:
+      console.log(
+        "This mode will run all the tests stored in the keploy/tests directory and report the results"
+      );
+      break;
+    default:
+      console.log(
+        "This mode will not do anything and your application will act normal without any interference from keploy"
+      );
+      break;
+  }
 }

--- a/mock/mock.ts
+++ b/mock/mock.ts
@@ -3,7 +3,7 @@ import * as grpc from "@grpc/grpc-js";
 import * as protoLoader from "@grpc/proto-loader";
 import path, { resolve } from "path";
 import { ProtoGrpcType } from "../proto/services";
-import Mode, { MODE_TEST } from "../src/mode";
+import Mode, { MODE_TEST, MODE_RECORD } from "../src/mode";
 import { createExecutionContext, getExecutionContext } from "../src/context";
 import { startRecordingMocks } from "./utils";
 
@@ -61,8 +61,9 @@ export function NewContext(conf: Config) {
   if (Mode.Valid(conf.Mode)) {
     mode.SetMode(conf.Mode);
   }
+  console.log("Keploy is running in " + mode.GetMode() + " mode");
   switch (mode.GetMode()) {
-    case "test":
+    case MODE_TEST:
       if (conf.Name === "") {
         console.log(
           "🚨 Please enter the auto generated name to mock the dependencies using Keploy."
@@ -84,7 +85,7 @@ export function NewContext(conf: Config) {
         return response;
       });
       break;
-    case "record":
+    case MODE_RECORD:
       createExecutionContext({
         mode: mode.GetMode(),
         testId: conf.Name,

--- a/src/keploy.ts
+++ b/src/keploy.ts
@@ -12,7 +12,7 @@ import { TestCase } from "../proto/services/TestCase";
 import { StrArr } from "../proto/services/StrArr";
 import assert = require("assert");
 import { createExecutionContext, getExecutionContext } from "./context";
-import Mode, { MODE_OFF } from "./mode";
+import Mode, { MODE_OFF, MODE_RECORD, MODE_TEST } from "./mode";
 
 const PROTO_PATH = "../proto/services.proto";
 const packageDef = protoLoader.loadSync(path.resolve(__dirname, PROTO_PATH));
@@ -86,6 +86,7 @@ export default class Keploy {
     this.dependencies = {};
     this.mocks = {};
     console.log("Keploy is running in " + this.mode.GetMode() + " mode");
+    this.modeDescription();
   }
 
   validateServerConfig({
@@ -445,5 +446,26 @@ export default class Keploy {
         return response;
       }
     );
+  }
+
+  // logs the description of the mode for the user to understand about the mode their application is running in
+  modeDescription() {
+    switch (this.mode.GetMode()) {
+      case MODE_RECORD:
+        console.log(
+          "This mode will record all the API calls made to the application and store each call as a test in the keploy/tests directory as a yaml file"
+        );
+        break;
+      case MODE_TEST:
+        console.log(
+          "This mode will run all the tests stored in the keploy/tests directory and report the results"
+        );
+        break;
+      default:
+        console.log(
+          "This mode will not do anything and your application will act normal without any interference from keploy"
+        );
+        break;
+    }
   }
 }

--- a/src/keploy.ts
+++ b/src/keploy.ts
@@ -85,6 +85,7 @@ export default class Keploy {
     this.responses = {};
     this.dependencies = {};
     this.mocks = {};
+    console.log("Keploy is running in " + this.mode.GetMode() + " mode");
   }
 
   validateServerConfig({


### PR DESCRIPTION
Fixes [#390](https://github.com/keploy/keploy/issues/390)

-  Adds logs in the constructor of keploy class and mock.ts
- Uses mode.GetMode() to get the mode instead of process.env as the mode in the .env can be some other than test, record or off 
- Add a modeDescription() function to log the description as writing a switch case or if there seemed to reduce the readability of the code