### PR TITLE
fetch http call/Signed-off-by: Vishal Myla <vishalmyla@gmail.com>

### DIFF
--- a/integrations/node-fetch/require.ts
+++ b/integrations/node-fetch/require.ts
@@ -43,7 +43,7 @@ export function wrappedNodeFetch(fetch: any) {
       getExecutionContext().context == undefined
     ) {
       console.error("keploy context is not present to mock dependencies");
-      return;
+      return fetchFunc.apply(this, [url, options]);
     }
     const ctx = getExecutionContext().context;
     let resp = new fetch.Response();


### PR DESCRIPTION
- The outcome of running fetchFunc with the url and options arguments using the apply method should be returned by the wrappedFetch function.
- The apply method sends the url and options parameters as an array and sets the this keyword within the fetchFunc function to the value of this inside the wrappedFetch function. This guarantees that fetchFunc is called correctly and with the appropriate parameters, returning the server answer.