### PR TITLE
fix: adds configuration for maxTimeout of keployTest and stops the ebpf hooks after keploy-test completion

### DIFF
--- a/keployCli.ts
+++ b/keployCli.ts
@@ -57,7 +57,7 @@ export const Test = async (appCmd: string, options: TestOptions, callback: (err:
                     break;
                 }
                 if (Date.now() - startTime > options.maxTimeout) {
-                    console.log("Timeout reached, exiting loop", Date.now() - startTime, options.maxTimeout);
+                    console.log("Timeout reached, exiting loop. maxTimeout: ", options.maxTimeout);
                     break;
                 }
                 console.log("testRun still in progress");

--- a/keployCli.ts
+++ b/keployCli.ts
@@ -32,10 +32,8 @@ export const Test = async (appCmd: string, options: TestOptions, callback: (err:
         appCmd = "npm start"
     }
     if (options.maxTimeout === 0 || options.maxTimeout === undefined || options.maxTimeout === null) {
-        console.log("setting the max timeout for the test to 30 seconds")
         options.maxTimeout = 30000;
     }
-    console.log("max timeout: ", options);
 
     let testResult = true;
     let startTime = Date.now();

--- a/keployCli.ts
+++ b/keployCli.ts
@@ -13,6 +13,11 @@ export enum TestRunStatus {
     FAILED = 'FAILED'
 }
 
+interface TestOptions {
+    maxTimeout: number;
+
+}
+
 let hasTestRunCompleted = false;
 
 export const setTestRunCompletionStatus = (status: boolean) => {
@@ -21,12 +26,18 @@ export const setTestRunCompletionStatus = (status: boolean) => {
 
 let userCommandPID: any = 0;
 
-export const Test = async (appCmd: string, options: any, callback: (err: Error | null, result?: boolean) => void) => {
+export const Test = async (appCmd: string, options: TestOptions, callback: (err: Error | null, result?: boolean) => void) => {
+    // set default values
     if (appCmd == "") {
         appCmd = "npm start"
     }
+    if (options.maxTimeout === 0 || options.maxTimeout === undefined || options.maxTimeout === null) {
+        console.log("setting the max timeout for the test to 30 seconds")
+        options.maxTimeout = 30000;
+    }
+    console.log("max timeout: ", options);
+
     let testResult = true;
-    const MAX_TIMEOUT = 10000;
     let startTime = Date.now();
     try {
         const testSets = await FetchTestSets();
@@ -41,17 +52,18 @@ export const Test = async (appCmd: string, options: any, callback: (err: Error |
             const testRunId = await RunTestSet(testset);
             let testRunStatus;
             while (true) {
-                await new Promise(res => setTimeout(res, 10000));
+                await new Promise(res => setTimeout(res, 2000));
                 testRunStatus = await FetchTestSetStatus(testRunId);
-                if (testRunStatus === TestRunStatus.RUNNING) {
-                    console.log("testRun still in progress");
-                    if (Date.now() - startTime > MAX_TIMEOUT) {
-                        console.log("Timeout reached, exiting loop");
-                        break;
-                    }
-                    continue;
+                // break the loop if the testRunStatus is not running or if it's been more than `maxTimeout` milliseconds
+                if (testRunStatus !== TestRunStatus.RUNNING) {
+                    break;
                 }
-                break;
+                if (Date.now() - startTime > options.maxTimeout) {
+                    console.log("Timeout reached, exiting loop", Date.now() - startTime, options.maxTimeout);
+                    break;
+                }
+                console.log("testRun still in progress");
+                // break;
             }
 
             if (testRunStatus === TestRunStatus.FAILED || testRunStatus === TestRunStatus.RUNNING) {
@@ -66,6 +78,8 @@ export const Test = async (appCmd: string, options: any, callback: (err: Error |
             StopUserApplication()
             await new Promise(res => setTimeout(res, 5000)); // wait for the application to stop
         }
+        // stop the ebpf hooks
+        stopTest();
         callback(null, testResult); // Callback with no error and the test result
     } catch (error) {
         callback(error as Error); // Callback with the error cast to an Error object
@@ -245,6 +259,27 @@ export const FetchTestSets = async (): Promise<string[] | null> => {
         }
     }
     return null;
+};
+
+const stopTest = async (): Promise<boolean> => {
+    try {
+        const client = await setHttpClient();
+        if (!client) throw new Error("Could not initialize HTTP client.");
+        const response = await client.post('', {
+            query: `{ stopTest }`
+        });
+        if (response.status >= 200 && response.status < 300) {
+            if (response.data && response.data.data) {
+                return response.data.data.stopTest;
+            } else {
+                console.error('Unexpected response structure', response.data);
+                return false;
+            }
+        }
+    } catch (error) {
+        console.error('Error stopping the test', error);
+    }
+    return false;
 };
 
 export const FetchTestSetStatus = async (testRunId: string): Promise<TestRunStatus | null> => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@keploy/sdk",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@keploy/sdk",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "@types/express": "^4.17.21",


### PR DESCRIPTION
Currently, the maxTimeout is 10 seconds and it is not possible to configure this timeout for the keploy-test file. So, there should be an option to pass the maxTimeout in the `Test` function call. And the ebpf hooks are unloaded after the keploy-test ran.